### PR TITLE
Fix MEME alphabet comparison error in tffm_module.py

### DIFF
--- a/tffm_module.py
+++ b/tffm_module.py
@@ -999,7 +999,7 @@ def tffm_from_meme(meme_output, kind, name="TFFM"):
     """
 
     record = motifs.parse(open(meme_output), 'MEME')
-    if record.alphabet != IUPAC.unambiguous_dna:
+    if record.alphabet != "".join(sorted(IUPAC.unambiguous_dna.letters)):
         sys.exit("### Wrong alphabet used in MEME ###")
     motif = record[0]
     nb_seq, nb_res, first_letters = utils.get_sequences_info(record.datafile)


### PR DESCRIPTION
## Problem
When running `tffm_module.py`, users encounter the error: **Wrong alphabet used in MEME**

## Root Cause
Line 1002 compares `record.alphabet` (an object) directly with `IUPAC.unambiguous_dna` (another object), which fails due to object identity comparison instead of content comparison.

## Solution
Changed the comparison to compare the sorted letters string instead of the alphabet objects:
- **Before:** `if record.alphabet != IUPAC.unambiguous_dna:`
- **After:** `if record.alphabet != "".join(sorted(IUPAC.unambiguous_dna.letters)):`

## Testing
- [x] Verified the fix resolves the original error
- [x] Tested that existing functionality remains intact

## Files Changed
- `tffm_module.py` (line 1002)

Fixes the MEME alphabet validation issue that prevents proper execution of the TFFM framework.